### PR TITLE
Adding riff-raff.yaml to deploy to frontend bucket

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,0 +1,11 @@
+regions: [eu-west-1]
+stacks: [frontend]
+deployments:
+  frontend-static/static/frontend/fonts:
+    type: aws-s3
+    contentDirectory: fonts/web
+    parameters:
+      bucket: aws-frontend-static
+      cacheControl: max-age=315360000
+      prefixStack: false
+


### PR DESCRIPTION
## What does this change?

Adds a `riff-raff.yaml` file to deploy web fonts to S3. I've created a corresponding Team City project https://teamcity.gutools.co.uk/viewLog.html?buildId=597885&buildTypeId=dotcom_Fonts&tab=buildResultsDiv&branch_dotcom=riff-raff-deployment

## How to test

Deploy to CODE using riff-raff.  Check that last-modified time on files in `s3://aws-frontend-static/CODE/frontend-static/static/frontend/fonts/` have updated