### PR TITLE
move to GitHub Actions (from TeamCity)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,42 @@
+name: CI
+
+on:
+  # Manual invocation.
+  workflow_dispatch:
+
+  push:
+
+jobs:
+  CI:
+    runs-on: ubuntu-latest
+
+    permissions:
+      # Allow GitHub to request an OIDC JWT ID token, for exchange with `aws-actions/configure-aws-credentials`
+      # See https://docs.github.com/en/actions/deployment/security-hardening-your-deployments/configuring-openid-connect-in-amazon-web-services#updating-your-github-actions-workflow
+      id-token: write
+
+      # Required for `actions/checkout`
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v3
+
+      # Exchange OIDC JWT ID token for temporary AWS credentials to allow uploading to S3
+      - uses: aws-actions/configure-aws-credentials@v1
+        with:
+          aws-region: eu-west-1
+          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
+
+      - name: Seed build number from TeamCity
+        run: |
+          LAST_TEAMCITY_BUILD=45
+          echo GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD )) >> $GITHUB_ENV
+
+      - uses: guardian/actions-riff-raff@v2
+        with:
+          projectName: dotcom::fonts
+          configPath: riff-raff.yaml
+          buildNumber: ${{ env.GITHUB_RUN_NUMBER }}
+          contentDirectories: |
+            frontend-static/static/frontend/fonts:
+              - fonts/web

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.idea

--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -1,9 +1,11 @@
 regions: [eu-west-1]
 stacks: [frontend]
+allowedStages:
+  - CODE
+  - PROD
 deployments:
   frontend-static/static/frontend/fonts:
     type: aws-s3
-    contentDirectory: fonts/web
     parameters:
       bucket: aws-frontend-static
       cacheControl: max-age=315360000


### PR DESCRIPTION
The TeamCity configuration was atypical (albeit simple) but it's opaque, not version controlled and requires VPN to inspect/update - GHA is ♾ better.