### PR TITLE
Add publicReadAcl to riff-raff.yaml

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,4 +8,5 @@ deployments:
       bucket: aws-frontend-static
       cacheControl: max-age=315360000
       prefixStack: false
+      publicReadAcl: false
 


### PR DESCRIPTION
## What does this change?
Adds `publicReadAcl`parameter to `riff-raff.yaml`. After [this change](https://github.com/guardian/riff-raff/pull/665) it is required.

The bucket is public so the individual files don't need a public read ACL (https://docs.aws.amazon.com/AmazonS3/latest/userguide/acl-overview.html).

