### PR TITLE
Add `immutable` to `cache-control`

### DIFF
--- a/riff-raff.yaml
+++ b/riff-raff.yaml
@@ -8,7 +8,7 @@ deployments:
     type: aws-s3
     parameters:
       bucket: aws-frontend-static
-      cacheControl: max-age=315360000
+      cacheControl: max-age=315360000, immutable
       prefixStack: false
       publicReadAcl: false
 


### PR DESCRIPTION
## What does this change?

adds the [`immutable`](https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Cache-Control#:~:text=opt%2Dout%20option.-,immutable,-The%20immutable%20response) directive to the assets `cache-control` header

## Why?

tells browsers (currently safari and firefox, ~40% of page views) they don't need to revalidate font files while the cache is fresh

## Linked PRs

https://github.com/guardian/dotcom-rendering/pull/7158
https://github.com/guardian/frontend/pull/25890

With assistance from @davidfurey 👍 