### PR TITLE
Add a swift package

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .DS_Store
 .idea
+.swiftpm/xcode/xcuserdata
+.swiftpm/xcode/package.xcworkspace/xcuserdata

--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,33 @@
+// swift-tools-version:5.5
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+// swiftlint:disable:next prefixed_toplevel_constant
+let package = Package(
+    name: "GuardianFonts",
+    platforms: [
+        .iOS("14.0.0")
+    ],
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "GuardianFonts",
+            targets: ["GuardianFonts"])
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "GuardianFonts",
+            dependencies: [],
+            resources: [.process("Fonts")]),
+        .testTarget(
+            name: "GuardianFontsTests",
+            dependencies: ["GuardianFonts"])
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ See the [Commercial Type EULA](legal/Commercial%20Type%20EULA%20Web-general.pdf)
 
 All of the files in the [`fonts/web`](fonts/web) directory are available from `https://assets.guim.co.uk/static/frontend/fonts/`.
 
+
+# Using fonts on Web
+
 ## 👍 Recommended `@font-face` rules
 
 You can see/copy-and-paste a complete example of the recommended rules in [`fonts/web/font-faces.css`](fonts/web/font-faces.css).
@@ -108,3 +111,77 @@ All of the files in the [`fonts/web`](fonts/web) directory are continuously depl
 ## Caching
 
 The cache control value for the font files is set to `max-age=315360000; immutable` (fresh for 10 years).
+
+
+# Using Fonts on iOS
+
+## Adding the Swift Package To Xcode
+
+To add the `GuardianFonts` Swift Package to your project, follow these steps:
+
+1. Open your project in Xcode.
+
+2. Go to `File` > `Swift Packages` > `Add Package Dependency...`.
+
+3. In the search bar, enter the URL `https://github.com/guardian/fonts.git` click `Next`.
+
+4. Select the version rule that suits your needs, then click `Next`.
+
+5. Choose the `GuardianFonts` library and click `Finish`.
+
+Now, the `GuardianFonts` Swift Package should be added to your project and you can import it wherever you need it.
+
+## Using in Another Swift Package
+
+If you're developing a Swift Package and want to use `GuardianFonts`, you can add it as a dependency in your `Package.swift` file.
+
+Here's how you can do it:
+
+1. Open your `Package.swift` file.
+
+2. Add `GuardianFonts` to the dependencies array:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/guardian/fonts.git", branch: "main")
+]
+```
+
+3. Add `GuardianFonts` as a dependency for your target:
+
+```swift
+targets: [
+    .target(
+            name: "YourPackageName",
+            dependencies: [
+                .product(name: "GuardianFonts", package: "fonts")
+            ]),
+]
+```
+
+4. Now, you can import `GuardianFonts` in any Swift file in your package.
+
+## Registration 
+Custom fonts are registered differently in Swift Packages due to the lack of an info.plist. 
+You should use `GuardianFonts.registerFonts()` function to register the fonts contained in this swift package to use in your application. 
+
+If using this from within another **module**, you can do the registration within the module's `init()` function. 
+
+Otherwise, from within a **project** this can be done within the App Delegate `application(_:willFinishLaunchingWithOptions:)` function.
+
+## Usage
+
+Wherever you want to use the module you can import it using: 
+`import GuardianFonts`
+
+###**UIKit**
+This swift package contains a convenience initialiser on UIFont, allowing you to create a font using a GuardianFontStyle in UIKit. 
+
+Example: 
+`let font = UIFont(style: .headlineRegular, size: 30)`
+
+###**SwiftUI**
+This swift package contains a modifier on `View`, allowing you to apply a font using a GuardianFontStyle in SwiftUI. 
+
+Example: 
+`Text("Hello World").font(.headlineRegular, size: 30, lineHeight: 34, verticalTrim: .standard)`

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Black.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Black.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Black.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-BlackItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-BlackItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-BlackItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Bold.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Bold.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Bold.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-BoldItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-BoldItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-BoldItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Light.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Light.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Light.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-LightItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-LightItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-LightItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Medium.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Medium.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Medium.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-MediumItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-MediumItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-MediumItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Regular.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Regular.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Regular.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-RegularItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-RegularItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-RegularItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Semibold.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-Semibold.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-Semibold.ttf

--- a/Sources/GuardianFonts/Fonts/GHGuardianHeadline-SemiboldItalic.ttf
+++ b/Sources/GuardianFonts/Fonts/GHGuardianHeadline-SemiboldItalic.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_headline_subset_apptt 180104/noalts_not_hinted/GHGuardianHeadline-SemiboldItalic.ttf

--- a/Sources/GuardianFonts/Fonts/GTGuardianTitlepiece-Bold.ttf
+++ b/Sources/GuardianFonts/Fonts/GTGuardianTitlepiece-Bold.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_titlepiece_subset_apptt 180118/noalts_not_hinted/GTGuardianTitlepiece-Bold.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Black.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Black.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-Black.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-BlackIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-BlackIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-BlackIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Bold.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Bold.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-Bold.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-BoldIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-BoldIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-BoldIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Med.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Med.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-Med.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-MedIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-MedIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-MedIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Reg.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-Reg.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-Reg.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-RegIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextEgyptian-RegIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textegyptian_subset_apptt 180410/noalts_not_hinted_webmetrics/GuardianTextEgyptian-RegIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-Black.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-Black.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-Black.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-BlackIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-BlackIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-BlackIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-Bold.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-Bold.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-Bold.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-BoldIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-BoldIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-BoldIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-Medium.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-Medium.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-Medium.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-MediumIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-MediumIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-MediumIt.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-Regular.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-Regular.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-Regular.ttf

--- a/Sources/GuardianFonts/Fonts/GuardianTextSans-RegularIt.ttf
+++ b/Sources/GuardianFonts/Fonts/GuardianTextSans-RegularIt.ttf
@@ -1,0 +1,1 @@
+../../../fonts/apps/guardian_textsans_subset_apptt 180413/noalts_not_hinted_webmetrics/GuardianTextSans-RegularIt.ttf

--- a/Sources/GuardianFonts/GuardianFonts.swift
+++ b/Sources/GuardianFonts/GuardianFonts.swift
@@ -1,0 +1,149 @@
+import UIKit
+
+/// An enumeration representing the various font styles used in the Guardian's digital platforms.
+/// Each case corresponds to a specific font style.
+///
+/// - Note: The font files and the CDN URLs at which they are hosted may only be used for Guardian websites or apps.
+/// All fonts are the property of Schwartzco, Inc., t/a Commercial Type (https://commercialtype.com/), and may not be reproduced without permission.
+@objc public enum GuardianFontStyle: Int, CaseIterable {
+    /// Titlepiece font style in bold.
+    case titlepieceBold
+
+    /// Headline font styles.
+    case headlineLight
+    case headlineLightItalic
+    case headlineRegular
+    case headlineRegularItalic
+    case headlineMedium
+    case headlineMediumItalic
+    case headlineSemibold
+    case headlineSemiboldItalic
+    case headlineBold
+    case headlineBoldItalic
+    case headlineBlack
+    case headlineBlackItalic
+
+    /// Text Egyptian font styles.
+    case textEgyptianRegular
+    case textEgyptianRegularItalic
+    case textEgyptianMedium
+    case textEgyptianMediumItalic
+    case textEgyptianBold
+    case textEgyptianBoldItalic
+    case textEgyptianBlack
+    case textEgyptianBlackItalic
+
+    /// Text Sans font styles.
+    case textSansRegular
+    case textSansRegularItalic
+    case textSansMedium
+    case textSansMediumItalic
+    case textSansBold
+    case textSansBoldItalic
+    case textSansBlack
+    case textSansBlackItalic
+
+    /// The name of the font associated with the style.
+    public var fontName: String {
+        GuardianFonts.fontName(for: self)
+    }
+}
+
+@objc
+public class GuardianFonts: NSObject {
+
+    override public init() {}
+
+    internal static var hasRegistered = false
+
+    @objc
+    public static func registerFonts() {
+        if !hasRegistered {
+            GuardianFontStyle.allCases.forEach {
+                registerFont(bundle: Bundle.module, fileName: $0.fontName, fontExtension: "ttf")
+            }
+            hasRegistered = true
+        }
+    }
+
+    /// Mapping from GuardianFontStyle to the font name
+    fileprivate static func fontName(for style: GuardianFontStyle) -> String {
+        switch style {
+        case .headlineBold:
+            return "GHGuardianHeadline-Bold"
+        case .headlineRegularItalic:
+            return "GHGuardianHeadline-RegularItalic"
+        case .headlineLight:
+            return "GHGuardianHeadline-Light"
+        case .headlineMedium:
+            return "GHGuardianHeadline-Medium"
+        case .headlineRegular:
+            return "GHGuardianHeadline-Regular"
+        case .headlineSemibold:
+            return "GHGuardianHeadline-Semibold"
+        case .headlineLightItalic:
+            return "GHGuardianHeadline-LightItalic"
+        case .headlineMediumItalic:
+            return "GHGuardianHeadline-MediumItalic"
+        case .headlineSemiboldItalic:
+            return "GHGuardianHeadline-SemiboldItalic"
+        case .headlineBoldItalic:
+            return "GHGuardianHeadline-BoldItalic"
+        case .headlineBlack:
+            return "GHGuardianHeadline-Black"
+        case .headlineBlackItalic:
+            return "GHGuardianHeadline-BlackItalic"
+        case .textSansBold:
+            return "GuardianTextSans-Bold"
+        case .textSansBoldItalic:
+            return "GuardianTextSans-BoldIt"
+        case .textSansRegular:
+            return "GuardianTextSans-Regular"
+        case .textSansRegularItalic:
+            return "GuardianTextSans-RegularIt"
+        case .textSansMedium:
+            return "GuardianTextSans-Medium"
+        case .textSansMediumItalic:
+            return "GuardianTextSans-MediumIt"
+        case .textSansBlack:
+            return "GuardianTextSans-Black"
+        case .textSansBlackItalic:
+            return "GuardianTextSans-BlackIt"
+        case .textEgyptianRegular:
+            return "GuardianTextEgyptian-Reg"
+        case .textEgyptianRegularItalic:
+            return "GuardianTextEgyptian-RegIt"
+        case .textEgyptianMedium:
+            return "GuardianTextEgyptian-Med"
+        case .textEgyptianMediumItalic:
+            return "GuardianTextEgyptian-MedIt"
+        case .textEgyptianBold:
+            return "GuardianTextEgyptian-Bold"
+        case .textEgyptianBoldItalic:
+            return "GuardianTextEgyptian-BoldIt"
+        case .textEgyptianBlack:
+            return "GuardianTextEgyptian-Black"
+        case .textEgyptianBlackItalic:
+            return "GuardianTextEgyptian-BlackIt"
+        case .titlepieceBold:
+            return "GTGuardianTitlepiece-Bold"
+        }
+    }
+
+
+    /// Register font file with the application
+    /// - Parameters:
+    ///   - bundle: Bundle containing the font file asset
+    ///   - fileName: Name of the font file
+    ///   - fontExtension: font file extension, eg. ttf
+    fileprivate static func registerFont(bundle: Bundle, fileName: String, fontExtension: String) {
+        guard let fontURL = bundle.url(forResource: fileName, withExtension: fontExtension),
+            let fontDataProvider = CGDataProvider(url: fontURL as CFURL),
+            let font = CGFont(fontDataProvider) else {
+            fatalError("Couldn't create font from filename: \(fileName) with extension \(fontExtension)")
+        }
+        var error: Unmanaged<CFError>?
+        // Register font with the Core Graphics Font Manager
+        CTFontManagerRegisterGraphicsFont(font, &error)
+    }
+}

--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -1,0 +1,113 @@
+//
+
+import SwiftUI
+
+public enum VerticalTrim {
+    case standard
+    case capToBaseline
+}
+
+public struct FontPad: ViewModifier {
+    internal init(fontName: String, fontSize: CGFloat, lineHeight: CGFloat? = nil, relativeStyle: Font.TextStyle, verticalTrim: VerticalTrim) {
+        self.fontName = fontName
+        self.fontSize = fontSize
+        self.lineHeight = lineHeight
+        self.relativeStyle = relativeStyle
+        self.verticalTrim = verticalTrim
+
+        self.font = UIFont(name: fontName, size: fontSize)
+    }
+
+    let fontName: String
+    let fontSize: CGFloat
+    let lineHeight: CGFloat?
+    let relativeStyle: Font.TextStyle
+
+    let verticalTrim: VerticalTrim
+
+    let font: UIFont?
+
+    private var topValue: CGFloat {
+        guard verticalTrim == .capToBaseline else { return 0 }
+        guard let font else { return 0 }
+        return -(font.ascender - font.capHeight)
+    }
+    private var bottomValue: CGFloat {
+        guard verticalTrim == .capToBaseline else { return 0 }
+        guard let font else { return 0 }
+        return font.descender
+    }
+    private var lineMultiple: CGFloat {
+        guard let lineHeight else { return 1 }
+        guard let font else { return 1 }
+        return lineHeight / font.lineHeight
+    }
+
+    public func body(content: Content) -> some View {
+        content
+            .font(Font.custom(fontName, size: fontSize, relativeTo: relativeStyle))
+            ._lineHeightMultiple(lineMultiple)
+            .multilineTextAlignment(.leading)
+            .padding(
+                .top,
+                topValue
+            )
+            .padding(
+                .bottom,
+                bottomValue
+            )
+    }
+}
+
+public extension View {
+    func font(
+        _ style: GuardianFontStyle,
+        size: CGFloat,
+        lineHeight: CGFloat? = nil,
+        verticalTrim: VerticalTrim = .capToBaseline
+    ) -> some View {
+        modifier(
+            FontPad(
+                fontName: style.fontName,
+                fontSize: size,
+                lineHeight: lineHeight,
+                relativeStyle: style.relativeStyle,
+                verticalTrim: verticalTrim
+            )
+        )
+    }
+}
+
+public extension View {
+    func previewFonts() -> some View {
+        onAppear {
+            GuardianFonts.registerFonts()
+        }
+    }
+}
+
+public extension GuardianFontStyle {
+    var relativeStyle: Font.TextStyle {
+        switch self {
+        case .headlineLight, .headlineRegular, .headlineMedium, .headlineBold, .headlineSemibold, .headlineRegularItalic, .headlineLightItalic, .headlineMediumItalic, .headlineSemiboldItalic, .headlineBoldItalic, .headlineBlack, .headlineBlackItalic:
+            return .headline
+        case .textSansBold, .textSansBoldItalic, .textSansRegular, .textSansRegularItalic, .textSansMedium, .textSansMediumItalic, .textSansBlack, .textSansBlackItalic:
+            return .body
+        case .textEgyptianRegular, .textEgyptianRegularItalic, .textEgyptianMedium, .textEgyptianMediumItalic, .textEgyptianBold, .textEgyptianBoldItalic, .textEgyptianBlack, .textEgyptianBlackItalic:
+            return .body
+        case .titlepieceBold:
+            return .title
+        }
+    }
+}
+public extension Font {
+    @available(*, deprecated, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
+    static func custom(style: GuardianFontStyle, size: CGFloat) -> Font {
+        Font.custom(style.fontName, size: size)
+    }
+
+    @available(*, deprecated, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
+    static func custom(style: GuardianFontStyle, size: CGFloat, relativeTo fontStyle: Font.TextStyle) -> Font {
+        Font.custom(style.fontName, size: size, relativeTo: fontStyle)
+    }
+}

--- a/Sources/GuardianFonts/UIFont+GuardianFontStyle.swift
+++ b/Sources/GuardianFonts/UIFont+GuardianFontStyle.swift
@@ -1,0 +1,26 @@
+//
+
+import UIKit
+
+public extension UIFont {
+    @objc
+    convenience init(style: GuardianFontStyle, size: CGFloat) {
+        self.init(style: style, size: size, useLiningNumbers: false)
+    }
+
+    @objc
+    convenience init(style: GuardianFontStyle, size: CGFloat, useLiningNumbers: Bool) {
+        if useLiningNumbers {
+            let feature: [UIFontDescriptor.FeatureKey: Int] = [.typeIdentifier: kUpperCaseNumbersSelector, .featureIdentifier: kNumberCaseType]
+            let descriptor = UIFontDescriptor(fontAttributes: [.name: style.fontName, .featureSettings: [feature]])
+            self.init(descriptor: descriptor, size: size)
+        } else {
+            self.init(name: style.fontName, size: size)!
+        }
+    }
+
+    @objc
+    static func fontName(for style: GuardianFontStyle) -> String {
+        style.fontName
+    }
+}

--- a/Tests/GuardianFontsTests/GuardianFontsTests.swift
+++ b/Tests/GuardianFontsTests/GuardianFontsTests.swift
@@ -1,0 +1,18 @@
+import XCTest
+@testable import GuardianFonts
+final class GuardianFontsTests: XCTestCase {
+
+    override func setUp() {
+        super.setUp()
+        GuardianFonts.registerFonts()
+    }
+
+
+    func testFonts() {
+        XCTAssert(GuardianFonts.hasRegistered == true, "We should have registered our fonts before we start")
+
+        for font in GuardianFontStyle.allCases {
+            XCTAssertNotNil(UIFont(name: font.fontName, size: 20), "\(font.fontName) was not found")
+        }
+    }
+}


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

This PR introduces a Swift Package to the repository, which provides a structured and standardized way to manage and share the Guardian's custom fonts for iOS projects.

The Swift Package, named GuardianFonts, includes all the font files along with a Swift file that provides a convenient interface for accessing these fonts.

The package uses a custom registration function, GuardianFonts.registerFonts(), to load the fonts at runtime. This is necessary because Swift Packages do not support the traditional method of loading custom fonts through the Info.plist file.

The package also provides extensions on UIFont and View (for SwiftUI) to make it easy to use the fonts in your code. You can create a UIFont with a specific GuardianFontStyle and size, or apply a GuardianFontStyle directly to a Text view in SwiftUI.

To use GuardianFonts in an iOS project, you can add it as a package dependency in Xcode. If you're developing a Swift Package and want to use GuardianFonts, you can add it as a dependency in your Package.swift file.

This addition will streamline the process of incorporating Guardian's custom fonts into any iOS project or Swift Package, ensuring consistency across different applications and simplifying updates or changes to the fonts.

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

I've written unit tests on the package that checks all fonts can register and be created.

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

While the GuardianFonts Swift Package provides a convenient way to use the Guardian's custom fonts in iOS projects, it's important to note that it does not currently include all the features used in the Guardian Live app. Specifically, it does not include the custom icons that are part of the app's user interface.