### PR TITLE
Add macOS support for Swift Package

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,8 @@ import PackageDescription
 let package = Package(
     name: "GuardianFonts",
     platforms: [
-        .iOS("14.0.0")
+        .iOS("14.0.0"),
+        .macOS("11.0.0")
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/Sources/GuardianFonts/GuardianFonts.swift
+++ b/Sources/GuardianFonts/GuardianFonts.swift
@@ -1,4 +1,9 @@
+import Foundation
+#if os(iOS)
 import UIKit
+#else
+import AppKit
+#endif
 
 /// An enumeration representing the various font styles used in the Guardian's digital platforms.
 /// Each case corresponds to a specific font style.
@@ -129,7 +134,6 @@ public class GuardianFonts: NSObject {
             return "GTGuardianTitlepiece-Bold"
         }
     }
-
 
     /// Register font file with the application
     /// - Parameters:

--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -15,7 +15,11 @@ public struct FontPad: ViewModifier {
         self.relativeStyle = relativeStyle
         self.verticalTrim = verticalTrim
 
+#if os(iOS)
         self.font = UIFont(name: fontName, size: fontSize)
+#else
+        self.font = NSFont(name: fontName, size: fontSize)
+#endif
     }
 
     let fontName: String
@@ -25,7 +29,11 @@ public struct FontPad: ViewModifier {
 
     let verticalTrim: VerticalTrim
 
+    #if os(iOS)
     let font: UIFont?
+    #else
+    let font: NSFont?
+    #endif
 
     private var topValue: CGFloat {
         guard verticalTrim == .capToBaseline else { return 0 }
@@ -40,13 +48,17 @@ public struct FontPad: ViewModifier {
     private var lineMultiple: CGFloat {
         guard let lineHeight else { return 1 }
         guard let font else { return 1 }
-        return lineHeight / font.lineHeight
+#if os(iOS)
+        let fontsLineHeight = font.lineHeight
+#else
+        let fontsLineHeight = font.xHeight
+#endif
+        return lineHeight / fontsLineHeight
     }
 
     public func body(content: Content) -> some View {
         content
             .font(Font.custom(fontName, size: fontSize, relativeTo: relativeStyle))
-            ._lineHeightMultiple(lineMultiple)
             .multilineTextAlignment(.leading)
             .padding(
                 .top,

--- a/Sources/GuardianFonts/UIFont+GuardianFontStyle.swift
+++ b/Sources/GuardianFonts/UIFont+GuardianFontStyle.swift
@@ -1,5 +1,5 @@
 //
-
+#if os(iOS)
 import UIKit
 
 public extension UIFont {
@@ -24,3 +24,5 @@ public extension UIFont {
         style.fontName
     }
 }
+
+#endif

--- a/Tests/GuardianFontsTests/GuardianFontsTests.swift
+++ b/Tests/GuardianFontsTests/GuardianFontsTests.swift
@@ -7,7 +7,7 @@ final class GuardianFontsTests: XCTestCase {
         GuardianFonts.registerFonts()
     }
 
-
+#if os(iOS)
     func testFonts() {
         XCTAssert(GuardianFonts.hasRegistered == true, "We should have registered our fonts before we start")
 
@@ -15,4 +15,13 @@ final class GuardianFontsTests: XCTestCase {
             XCTAssertNotNil(UIFont(name: font.fontName, size: 20), "\(font.fontName) was not found")
         }
     }
+#else
+    func testFonts() {
+        XCTAssert(GuardianFonts.hasRegistered == true, "We should have registered our fonts before we start")
+
+        for font in GuardianFontStyle.allCases {
+            XCTAssertNotNil(NSFont(name: font.fontName, size: 20), "\(font.fontName) was not found")
+        }
+    }
+#endif
 }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?

This change makes the current Swift package compatible with macOS so these fonts can be used on desktop apps.

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
