### PR TITLE
Update swift package to include GuardianFont encapsulation type

### DIFF
--- a/Sources/GuardianFonts/GuardianFont.swift
+++ b/Sources/GuardianFonts/GuardianFont.swift
@@ -1,6 +1,7 @@
 import Foundation
 import SwiftUI
 
+/// This type encaspulates the GuardianFontStyle, size and line height to be applied.
 public struct GuardianFont {
     public let style: GuardianFontStyle
     public let size: CGFloat

--- a/Sources/GuardianFonts/GuardianFont.swift
+++ b/Sources/GuardianFonts/GuardianFont.swift
@@ -1,0 +1,22 @@
+import Foundation
+import SwiftUI
+
+public struct GuardianFont {
+    public let style: GuardianFontStyle
+    public let size: CGFloat
+    public let lineHeight: CGFloat?
+
+    public var font: Font {
+        Font.custom(style.fontName, size: size)
+    }
+
+    public var uiFont: UIFont {
+        UIFont(name: style.fontName, size: size) ?? .systemFont(ofSize: size)
+    }
+
+    public init(style: GuardianFontStyle, size: CGFloat, lineHeight: CGFloat? = nil) {
+        self.style = style
+        self.size = size
+        self.lineHeight = lineHeight
+    }
+}

--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -72,18 +72,63 @@ public struct FontPad: ViewModifier {
 }
 
 public extension View {
+    /// Use this function on a view to apply a Guardian Font Style.
+    /// This is preferred and more in line with SwiftUI best practices.
+    ///
+    /// For example: `.font(.textSansRegular, size: 14)`
+    /// Here `.textSansRegular` is a GuardianFontStyle.
+    ///
+    /// To have a fixedSize, add `.dynamicTypeSize(.large)` line after this function
+    ///
+    /// - Parameters:
+    ///   - style: GuardianFontStyle to be applied to the text
+    ///   - size: Intended size of the text
+    ///   - lineHeight: Custom line height. Nil by default
+    ///   - verticalTrim: Custom vertical trim for the font. `.capToBaseline` by default. Can be set to `.standard` to have some vertical padding.
+    ///   - relativeStyle: Relative dynamic scale type. This is nil be default in which case, the relative style is defined by the `style` parameter.
+    /// - Returns: Modified view with the Guardian Font applied
     func font(
         _ style: GuardianFontStyle,
         size: CGFloat,
         lineHeight: CGFloat? = nil,
-        verticalTrim: VerticalTrim = .capToBaseline
+        verticalTrim: VerticalTrim = .capToBaseline,
+        relativeStyle: Font.TextStyle? = nil
     ) -> some View {
         modifier(
             FontPad(
                 fontName: style.fontName,
                 fontSize: size,
                 lineHeight: lineHeight,
-                relativeStyle: style.relativeStyle,
+                relativeStyle: relativeStyle ?? style.relativeStyle,
+                verticalTrim: verticalTrim
+            )
+        )
+    }
+
+    /// Use this function on a view to apply a GuardianFont.
+    /// This can be used if you're defnining GuardianFont to be applied somewhere separately.
+    ///
+    /// For example: `.font(.guardianSubtitle, verticalTrim: .standard)`
+    /// Here `.guardianSubtitle` is a GuardianFont.
+    ///
+    /// To have a fixedSize, add `.dynamicTypeSize(.large)` line after this function
+    ///
+    /// - Parameters:
+    ///   - font: GuardianFont encapsulating the GuardianFontStyle, size and line height to be applied.
+    ///   - verticalTrim: Custom vertical trim for the font. `.capToBaseline` by default. Can be set to `.standard` to have some vertical padding.
+    ///   - relativeStyle: Relative dynamic scale type. This is nil be default in which case, the relative style is defined by the `style` parameter.
+    /// - Returns: Modified view with the Guardian Font applied
+    func font(
+        _ font: GuardianFont,
+        verticalTrim: VerticalTrim = .capToBaseline,
+        relativeStyle: Font.TextStyle? = nil
+    ) -> some View {
+        modifier(
+            FontPad(
+                fontName: font.style.fontName,
+                fontSize: font.size,
+                lineHeight: font.lineHeight,
+                relativeStyle: relativeStyle ?? font.style.relativeStyle,
                 verticalTrim: verticalTrim
             )
         )


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
The iOS live app is looking to start using the `GuardianFonts` swift package. There is a `GuardianFont` type used by the live app to encapsulate the required properties of the Guardian font. This PR adds that type to the fonts swift package along with some SwiftUI view modifiers that reference that type. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
This is just an addition and so won't affect other projects that already use the `GuardianFonts` swift package. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
