### PR TITLE
bump actions-riff-raff to v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,22 +18,21 @@ jobs:
       # Required for `actions/checkout`
       contents: read
 
+      # Required for riff-raff action
+      pull-requests: write
+
     steps:
       - uses: actions/checkout@v3
-
-      # Exchange OIDC JWT ID token for temporary AWS credentials to allow uploading to S3
-      - uses: aws-actions/configure-aws-credentials@v1
-        with:
-          aws-region: eu-west-1
-          role-to-assume: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
 
       - name: Seed build number from TeamCity
         run: |
           LAST_TEAMCITY_BUILD=45
           echo GITHUB_RUN_NUMBER=$(( $GITHUB_RUN_NUMBER + $LAST_TEAMCITY_BUILD )) >> $GITHUB_ENV
 
-      - uses: guardian/actions-riff-raff@v2
+      - uses: guardian/actions-riff-raff@v4
         with:
+          githubToken: ${{ secrets.GITHUB_TOKEN }}
+          roleArn: ${{ secrets.GU_RIFF_RAFF_ROLE_ARN }}
           projectName: dotcom::fonts
           configPath: riff-raff.yaml
           buildNumber: ${{ env.GITHUB_RUN_NUMBER }}


### PR DESCRIPTION
## What is the value of this and can you measure success?

Upgrades to use the latest version of `guardian/actions-riff-raff`.

Part of https://github.com/guardian/dotcom-rendering/issues/10600

## What does this change?

- Adds write permissions for pull requests and adds `githubToken` to the job step as [required in the major version bump for v3](https://github.com/guardian/actions-riff-raff/releases/tag/v3.0.0)
- Removes step to configure AWS credentials and uses the AWS role ARN directly in the riff-raff action [as required in the major bump for v4](https://github.com/guardian/actions-riff-raff/releases/tag/v4)

## Testing

- [x] verified that this branch successfully uploaded to riffraff
- [x] deployed branch on CODE