### PR TITLE
Add line spacing to SwiftUI modifier

### DIFF
--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -56,9 +56,17 @@ public struct FontPad: ViewModifier {
         return lineHeight / fontsLineHeight
     }
 
+    private var lineSpacing: CGFloat {
+        guard let lineHeight else { return 0 }
+        guard let font else { return 0 }
+        let fontsLineHeight = font.lineHeight
+        return lineHeight - fontsLineHeight
+    }
+
     public func body(content: Content) -> some View {
         content
             .font(Font.custom(fontName, size: fontSize, relativeTo: relativeStyle))
+            .lineSpacing(lineSpacing)
             .multilineTextAlignment(.leading)
             .padding(
                 .top,


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
This PR adjusts the `FontPad` SwiftUI ViewModifier so that if provided a line height it can apply `lineSpacing` based on the internal font file line height. 
Font files have inherited line heights, hence why the line spacing calculation factors that in. 

There is one limitation with this approach currently in that the `lineSpacing` modifier cannot apply negative spacing, meaning that if the inherited line height from the font file is greater than the line height specified it will not be reduced beyond what the font file declares. 

For reference, the inherited line height from the font files are: 
* GTGuardianTitlepiece-Bold 1.25
* GHGuardianHeadline-Light 1.25
* GHGuardianHeadline-LightItalic 1.25
* GHGuardianHeadline-Regular 1.25
* GHGuardianHeadline-RegularItalic 1.25
* GHGuardianHeadline-Medium 1.25
* GHGuardianHeadline-MediumItalic 1.25
* GHGuardianHeadline-Semibold 1.25
* GHGuardianHeadline-SemiboldItalic 1.25
* GHGuardianHeadline-Bold 1.25
* GHGuardianHeadline-BoldItalic 1.25
* GHGuardianHeadline-Black 1.25
* GHGuardianHeadline-BlackItalic 1.25
* GuardianTextEgyptian-Reg 1.24
* GuardianTextEgyptian-RegIt 1.24
* GuardianTextEgyptian-Med 1.24
* GuardianTextEgyptian-MedIt 1.24
* GuardianTextEgyptian-Bold 1.24
* GuardianTextEgyptian-BoldIt 1.24
* GuardianTextEgyptian-Black 1.24
* GuardianTextEgyptian-BlackIt 1.24
* GuardianTextSans-Regular 1.23
* GuardianTextSans-RegularIt 1.23
* GuardianTextSans-Medium 1.23
* GuardianTextSans-MediumIt 1.23
* GuardianTextSans-Bold 1.23
* GuardianTextSans-BoldIt 1.23
* GuardianTextSans-Black 1.23
* GuardianTextSans-BlackIt 1.23

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
