### PR TITLE
Add future deprecation version to custom font modifier to suppress warning

### DIFF
--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -166,12 +166,12 @@ public extension GuardianFontStyle {
     }
 }
 public extension Font {
-    @available(*, deprecated, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
+    @available(iOS, deprecated: 100000.0, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
     static func custom(style: GuardianFontStyle, size: CGFloat) -> Font {
         Font.custom(style.fontName, size: size)
     }
 
-    @available(*, deprecated, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
+    @available(iOS, deprecated: 100000.0, message: "This method is no longer supported. Use `View.font(:size:lineHeight:verticalTrim:)` instead")
     static func custom(style: GuardianFontStyle, size: CGFloat, relativeTo fontStyle: Font.TextStyle) -> Font {
         Font.custom(style.fontName, size: size, relativeTo: fontStyle)
     }


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
Although the preferred method of setting custom fonts is via the `View.font(:size:lineHeight:verticalTrim:)` view modifier, there are times when we need to be able to set a custom Guardian font via the `Font.custom(style: GuardianFontStyle, size: CGFloat)` modifier. 
Specifically in my case, I need to set a font on an `AttributedString` in order to concatenate two strings with different font styles. 
In this PR, I have followed the deprecation style used by Apple for the `foregroundColor` modifier - this means that although the compiler marks it as deprecated at the point of use it doesn't generate a warning in the project. 

<img width="649" alt="Screenshot 2024-06-05 at 15 52 27" src="https://github.com/guardian/fonts/assets/53755195/e9fc057c-5fc3-49ef-9ea8-aea926d66ad9">




#### For reference, the`foregroundColor` modifier: 
![Screenshot 2024-06-05 at 16 03 43](https://github.com/guardian/fonts/assets/53755195/253e76fe-a534-4fbf-89ed-12751ae95095)

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test
To test this out you can try accessing the modifier, eg. `.font(Font.custom(style: .headlineLight, size: 14))` in a view and observe the behaviour when used. Although flagged as deprecated when choosing, it doesn't generate a warning. 

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
