### PR TITLE
Add macos support to GuardianFont SwiftUI files

### DIFF
--- a/Sources/GuardianFonts/GuardianFont.swift
+++ b/Sources/GuardianFonts/GuardianFont.swift
@@ -7,13 +7,23 @@ public struct GuardianFont {
     public let size: CGFloat
     public let lineHeight: CGFloat?
 
+    public var rawValue: Font {
+        font
+    }
+
     public var font: Font {
         Font.custom(style.fontName, size: size)
     }
 
+#if os(iOS)
     public var uiFont: UIFont {
         UIFont(name: style.fontName, size: size) ?? .systemFont(ofSize: size)
     }
+    #else
+    public var nsFont: NSFont {
+        NSFont(name: style.fontName, size: size) ?? .systemFont(ofSize: size)
+    }
+    #endif
 
     public init(style: GuardianFontStyle, size: CGFloat, lineHeight: CGFloat? = nil) {
         self.style = style

--- a/Sources/GuardianFonts/GuardianFont.swift
+++ b/Sources/GuardianFonts/GuardianFont.swift
@@ -7,10 +7,6 @@ public struct GuardianFont {
     public let size: CGFloat
     public let lineHeight: CGFloat?
 
-    public var rawValue: Font {
-        font
-    }
-
     public var font: Font {
         Font.custom(style.fontName, size: size)
     }

--- a/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
+++ b/Sources/GuardianFonts/SwiftUI+GuardianFonts.swift
@@ -59,7 +59,11 @@ public struct FontPad: ViewModifier {
     private var lineSpacing: CGFloat {
         guard let lineHeight else { return 0 }
         guard let font else { return 0 }
+#if os(iOS)
         let fontsLineHeight = font.lineHeight
+#else
+        let fontsLineHeight = font.xHeight
+#endif
         return lineHeight - fontsLineHeight
     }
 


### PR DESCRIPTION
<!-- See https://github.com/guardian/recommendations/blob/main/pull-requests.md for recommendations on raising and reviewing pull requests. -->

## What does this change?
As part of work on the Source apps repo in which I am adding a sample macos app, I have updated some of the SwiftUI logic for macos support. 

<!-- A PR should have enough detail to be understandable far in the future. e.g what is the problem/why is the change needed, how does it solve it and any questions or points of discussion. Prefer copying information from a Trello card over linking to it; the card may not always exist and reviewers may not have access to the board. -->

## How to test

<!-- Provide instructions to help others verify the change. This could take the form of "On PROD, do X and witness Y. On this branch, do X and witness Z. " -->

## How can we measure success?

<!-- Do you expect errors to decrease? Do you expect user journeys to be simplified? What can be used to prove this? A filtered view of logs or analytics, etc? -->

## Have we considered potential risks?

<!-- What are the potential risks and how can they be mitigated? Does an error require an alarm? Should user help, infosec, or legal be informed of this change? Is private information guarded? Do we need to add anything in the backlog? -->

## Images

<!-- Usually only applicable to UI changes, what did it look like before and what will it look like after? -->

## Accessibility

<!-- Usually only applicable to UI changes, check the boxes if you are satisfied that your changes pass these tests -->

-   [ ] [Tested with screen reader](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#screen-reader)
-   [ ] [Navigable with keyboard](https://github.com/guardian/accessibility/blob/main/people-and-technology/02-physical.md#keyboard)
-   [ ] [Colour contrast passed](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#contrast)
-   [ ] [The change doesn't use only colour to convey meaning](https://github.com/guardian/accessibility/blob/main/people-and-technology/03-visual.md#use-of-colour)
